### PR TITLE
Add configurable loot directory

### DIFF
--- a/utils/auto-exploit.py
+++ b/utils/auto-exploit.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 import os, json, ftplib, argparse, subprocess, glob
+
+LOOT_DIR = "loot"
+PAYLOAD_DIR = "payloads"
 from io import BytesIO
 from datetime import datetime
 from impacket.smbconnection import SMBConnection
@@ -34,7 +37,7 @@ exploit -j
     print(f"[+] Metasploit handler .rc file written: {filename}")
 
 def load_loot(ip, proto):
-    path = f"loot/{proto}-{ip.replace('.', '_')}.json"
+    path = os.path.join(LOOT_DIR, f"{proto}-{ip.replace('.', '_')}.json")
     if os.path.exists(path):
         with open(path) as f:
             return json.load(f)
@@ -50,13 +53,14 @@ def save_log(ip, lines):
 # === Payload Auto-Selection ===
 def find_payloads_for(proto):
     if proto == "ftp":
-        return glob.glob("payloads/web/*.php") + glob.glob("payloads/web/*.asp")
+        return glob.glob(os.path.join(PAYLOAD_DIR, "web", "*.php")) + \
+               glob.glob(os.path.join(PAYLOAD_DIR, "web", "*.asp"))
     if proto == "smb":
         return (
-            glob.glob("payloads/windows/*.ps1") +
-            glob.glob("payloads/windows/*.bat") +
-            glob.glob("payloads/linux/*.sh") +
-            glob.glob("payloads/linux/*.c")
+            glob.glob(os.path.join(PAYLOAD_DIR, "windows", "*.ps1")) +
+            glob.glob(os.path.join(PAYLOAD_DIR, "windows", "*.bat")) +
+            glob.glob(os.path.join(PAYLOAD_DIR, "linux", "*.sh")) +
+            glob.glob(os.path.join(PAYLOAD_DIR, "linux", "*.c"))
         )
     return []
 
@@ -137,7 +141,10 @@ def upload_smb_shell(smb_loot, ip, callback):
         log.append("[!] No SMB payloads uploaded.")
     return log
 
-def auto_exploit(ip, callback, listen, http_listen, generate_rc):
+def auto_exploit(ip, callback, listen, http_listen, generate_rc, loot_dir="loot", payload_dir="payloads"):
+    global LOOT_DIR, PAYLOAD_DIR
+    LOOT_DIR = loot_dir
+    PAYLOAD_DIR = payload_dir
     print(f"\n[+] Auto-Exploitation for {ip}")
 
     if listen and callback:
@@ -181,6 +188,8 @@ if __name__ == "__main__":
     parser.add_argument("--listen", action="store_true", help="Launch Netcat listener")
     parser.add_argument("--http-listen", action="store_true", help="Start HTTP beacon catcher")
     parser.add_argument("--generate-rc", action="store_true", help="Write Metasploit .rc file")
+    parser.add_argument("--loot-dir", default="loot", help="Directory of loot JSON files")
+    parser.add_argument("--payload-dir", default="payloads", help="Directory of payload files")
 
     args = parser.parse_args()
     auto_exploit(
@@ -188,6 +197,8 @@ if __name__ == "__main__":
         callback=args.callback,
         listen=args.listen,
         http_listen=args.http_listen,
-        generate_rc=args.generate_rc
+        generate_rc=args.generate_rc,
+        loot_dir=args.loot_dir,
+        payload_dir=args.payload_dir
     )
 

--- a/utils/auto-nse.py
+++ b/utils/auto-nse.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 import json, argparse, os, subprocess
 
+LOOT_DIR = "loot"
+
 def resolve_script(script_name):
     return f"./nse/{script_name}" if os.path.exists(f"./nse/{script_name}") else script_name
 
 def load_loot(ip, proto):
-    path = f"loot/{proto}-{ip.replace('.', '_')}.json"
+    path = os.path.join(LOOT_DIR, f"{proto}-{ip.replace('.', '_')}.json")
     if os.path.exists(path):
         with open(path) as f:
             return json.load(f)
@@ -41,7 +43,9 @@ def suggest_smb(smb_data, target):
         cmds.append(("smb", cmd))
     return cmds
 
-def auto_nse(target, modules=None, run=False, export_plan=None, dry_run_json=False, auto_chain=False, callback=None, loot_only=False):
+def auto_nse(target, modules=None, run=False, export_plan=None, dry_run_json=False, auto_chain=False, callback=None, loot_only=False, loot_dir="loot"):
+    global LOOT_DIR
+    LOOT_DIR = loot_dir
     print(f"\n[+] Auto-NSE v3 starting for {target}")
 
     allowed = modules if modules else ["ftp", "smb", "http"]
@@ -117,6 +121,7 @@ if __name__ == "__main__":
     parser.add_argument("--auto-chain", action="store_true", help="Run auto-exploit after NSE")
     parser.add_argument("--callback", help="Callback IP:PORT (for shell or RC)")
     parser.add_argument("--loot-only", action="store_true", help="Only parse loot, skip NSE")
+    parser.add_argument("--loot-dir", default="loot", help="Directory of loot JSON files")
 
     args = parser.parse_args()
     module_list = args.modules.split(",") if args.modules else None
@@ -129,6 +134,7 @@ if __name__ == "__main__":
         dry_run_json=args.dry_run_json,
         auto_chain=args.auto_chain,
         callback=args.callback,
-        loot_only=args.loot_only
+        loot_only=args.loot_only,
+        loot_dir=args.loot_dir
     )
 

--- a/utils/recon/ftp_recon.py
+++ b/utils/recon/ftp_recon.py
@@ -9,9 +9,9 @@ from io import BytesIO
 def ftp_banner(msg):
     print(f"\n[+] {msg}")
 
-def save_loot(host, data):
-    os.makedirs("loot", exist_ok=True)
-    filename = f"loot/ftp-{host.replace('.', '_')}.json"
+def save_loot(host, data, loot_dir):
+    os.makedirs(loot_dir, exist_ok=True)
+    filename = os.path.join(loot_dir, f"ftp-{host.replace('.', '_')}.json")
     with open(filename, "w") as f:
         json.dump(data, f, indent=2)
     print(f"\n[+] Loot saved: {filename}")
@@ -95,7 +95,7 @@ def detect_vulnerabilities(banner_text):
         vulns.append("ProFTPD 1.3.5 - CVE-2015-3306 (mod_copy)")
     return vulns
 
-def ftp_recon(host, port, user, passwd, verify_upload):
+def ftp_recon(host, port, user, passwd, verify_upload, loot_dir):
     result = {
         "target": host,
         "port": port,
@@ -148,7 +148,7 @@ def ftp_recon(host, port, user, passwd, verify_upload):
     result["vulnerabilities"] = detect_vulnerabilities(banner_text)
 
     ftp.quit()
-    save_loot(host, result)
+    save_loot(host, result, loot_dir)
 
     # Summary
     ftp_banner("Operator Summary:")
@@ -177,6 +177,7 @@ if __name__ == "__main__":
     parser.add_argument("--user", default="anonymous", help="FTP username")
     parser.add_argument("--password", dest="password", default="anonymous@ftp", help="FTP password")
     parser.add_argument("--verify-upload", action="store_true", help="Try uploading a test file to writable dir")
+    parser.add_argument("--loot-dir", default="loot", help="Directory to store loot JSON")
     args = parser.parse_args()
 
-    ftp_recon(args.target, args.port, args.user, args.password, args.verify_upload)
+    ftp_recon(args.target, args.port, args.user, args.password, args.verify_upload, args.loot_dir)

--- a/utils/recon/http_recon.py
+++ b/utils/recon/http_recon.py
@@ -35,15 +35,15 @@ def looks_like_json_login(response):
             return True
     return False
 
-def save_loot(target, data):
-    os.makedirs("loot", exist_ok=True)
+def save_loot(target, data, loot_dir):
+    os.makedirs(loot_dir, exist_ok=True)
     slug = re.sub(r'[^a-zA-Z0-9]', '_', target)
-    filename = f"loot/http-{slug}.json"
+    filename = os.path.join(loot_dir, f"http-{slug}.json")
     with open(filename, "w") as f:
         json.dump(data, f, indent=2)
     print(f"\n[+] Loot saved to {filename}")
 
-def scan_http(target, quick=False):
+def scan_http(target, quick=False, loot_dir="loot"):
     print(f"\n[+] Starting HTTP Recon: {target}")
     try:
         r = requests.get(target, timeout=5, verify=False, headers=HEADERS)
@@ -117,14 +117,15 @@ def scan_http(target, quick=False):
             print(f"    [!] Error checking {url}: {e}")
             continue
 
-    save_loot(host, results)
+    save_loot(host, results, loot_dir)
 
 def cli():
     parser = argparse.ArgumentParser(description="HTTP recon tool for Dharma-Tools")
     parser.add_argument("target", help="Target base URL (e.g. http://10.10.10.42)")
     parser.add_argument("--quick", action="store_true", help="Limit to top 3 common paths")
+    parser.add_argument("--loot-dir", default="loot", help="Directory to store loot JSON")
     return parser.parse_args()
 
 if __name__ == "__main__":
     args = cli()
-    scan_http(args.target, quick=args.quick)
+    scan_http(args.target, quick=args.quick, loot_dir=args.loot_dir)

--- a/utils/recon/smb_recon.py
+++ b/utils/recon/smb_recon.py
@@ -9,9 +9,9 @@ COMMON_PIPES = ['lsarpc', 'samr', 'svcctl', 'netlogon', 'spoolss', 'browser']
 def banner(text):
     print(f"\n[+] {text}")
 
-def save_loot(host, data):
-    os.makedirs("loot", exist_ok=True)
-    filename = f"loot/smb-{host.replace('.', '_')}.json"
+def save_loot(host, data, loot_dir):
+    os.makedirs(loot_dir, exist_ok=True)
+    filename = os.path.join(loot_dir, f"smb-{host.replace('.', '_')}.json")
     with open(filename, "w") as f:
         json.dump(data, f, indent=2)
     print(f"\n[+] Loot saved: {filename}")
@@ -65,7 +65,7 @@ def bruteforce_users_via_sid(host, sid_base, start=500, stop=550):
         print(f"[-] RID brute failed: {e}")
     return found_users
 
-def smb_recon(host, port=445):
+def smb_recon(host, port=445, loot_dir="loot"):
     loot = {
         "target": host,
         "port": port,
@@ -137,7 +137,7 @@ def smb_recon(host, port=445):
     else:
         print("    Could not retrieve SID.")
 
-    save_loot(host, loot)
+    save_loot(host, loot, loot_dir)
 
     # Operator summary
     banner("Operator Summary")
@@ -172,7 +172,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Full-spectrum SMB recon for Dharma-Tools")
     parser.add_argument("--target", required=True, help="Target IP or hostname")
     parser.add_argument("--port", type=int, default=445, help="SMB port (default 445)")
+    parser.add_argument("--loot-dir", default="loot", help="Directory to store loot JSON")
     args = parser.parse_args()
 
-    smb_recon(args.target, args.port)
+    smb_recon(args.target, args.port, loot_dir=args.loot_dir)
 


### PR DESCRIPTION
## Summary
- enable --loot-dir support for recon modules
- allow auto-nse and auto-exploit to specify loot directory
- enable auto-exploit to set payload directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2af623908323bc51666b1722bab5