### PR TITLE
Fix console reassignment in main

### DIFF
--- a/dharma.py
+++ b/dharma.py
@@ -94,6 +94,7 @@ def run_payload(args):
 
 
 def main():
+    global console
     parser = argparse.ArgumentParser(
         prog="dharma.py", description="Dharma-Tools Central CLI"
     )


### PR DESCRIPTION
## Summary
- declare `global console` in `main()` before reassigning it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b30e309b08323864a51e2a1bf18c1